### PR TITLE
Avoid importing freeboxpy from setup.py to fix install error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,33 @@
 # -*- coding: utf-8 -*-
 
+import codecs
+import os
+import re
 from setuptools import setup, find_packages
 
-import freepybox
+
+# Method for retrieving the version is taken from the setup.py of pip itself:
+# https://github.com/pypa/pip/blob/master/setup.py
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name='freepybox',
-    version=freepybox.__version__,
+    version=find_version("freepybox", "__init__.py"),
     packages=find_packages(),
     author='fstercq',
     author_email='',


### PR DESCRIPTION
Trying to install freepybox with pip fails with a "ModuleNotFoundError" if "requests" is not installed yet. This is due to the import of freepybox in setup.py, wich triggers the import of "requests" before it has been installed through the install_requires.

I changed the setup.py to read the version number directly from init.py, without importing, as is done in the setup.py of pip.