### PR TITLE
Use logging instead of print for info and error messages

### DIFF
--- a/freepybox/api/fs.py
+++ b/freepybox/api/fs.py
@@ -1,5 +1,8 @@
 import base64
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 class Fs:
 
@@ -22,7 +25,7 @@ class Fs:
         if self._path_exists(path):
             self._path = os.path.join(self._path, path)
         else:
-            print('{0} does not exist'.format(os.path.join(self._path, path)))
+            logger.error('{0} does not exist'.format(os.path.join(self._path, path)))
 
 
     def _path_exists(self, path):

--- a/freepybox/api/fsnav.py
+++ b/freepybox/api/fsnav.py
@@ -1,5 +1,8 @@
 from .fs import Fs
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 class Fsnav:
 
@@ -30,7 +33,7 @@ class Fsnav:
             if self._path_exists(path):
                 self._path = os.path.join(self._path, path)
             else:
-                print('{0} does not exist'.format(os.path.join(self._path, path)))
+                logger.error('{0} does not exist'.format(os.path.join(self._path, path)))
 
 
     def _path_exists(self, path):


### PR DESCRIPTION
To enable filtering and custom handlers, it is better to use logging rather than print to log messages. I left some prints when they were actual interactions with the user of the library (request for manual validation on the freebox, output of filesystem commands).