### PR TITLE
Create new var to write in the token file

### DIFF
--- a/freepybox/freepybox.py
+++ b/freepybox/freepybox.py
@@ -173,8 +173,7 @@ class Freepybox:
         """
         Store the application token in g_app_auth_file file
         """
-        d = app_desc
-        d.update({'app_token': app_token, 'track_id': track_id})
+        d = {**app_desc, 'app_token': app_token, 'track_id': track_id}
 
         with open(file, 'w') as f:
             json.dump(d, f)


### PR DESCRIPTION
Leave app_desc untouched before writing in token file (function _writefile_app_token)
otherwise creating a Freebox instance twice in a row will fail
(the app_desc read from the file will be different from the one
in memory since it has been changed before writing the auth file)