### PR TITLE
Add a connection module to get WAN status / v1.1

### DIFF
--- a/exemple-wan.py
+++ b/exemple-wan.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+'''
+This example can be run safely as it won't change anything in your box configuration
+'''
+from freepybox import Freepybox
+
+# Instantiate Freepybox class using default application descriptor 
+# and default token_file location
+fbx = Freepybox()
+
+# Connect to the freebox with default http protocol
+# and default port 80
+# Be ready to authorize the application on the Freebox if you use this
+# example for the first time
+fbx.open('mafreebox.freebox.fr', 80)
+
+# Extract WAN interface status (GET /api/v6/connection/full) using connection API
+fbx_connection_status_details = fbx.connection.get_status_details()
+#print(fbx_connection_status_details)
+
+print('### WAN ###')
+print('WAN ipv4 address: {0}'.format(fbx_connection_status_details['ipv4']))
+print('WAN ipv6 address: {0}'.format(fbx_connection_status_details['ipv6']))
+print('WAN status: {0}'.format(fbx_connection_status_details['state']))
+
+print('WAN down bandwidth: {0} Mb'.format(fbx_connection_status_details['bandwidth_down']/1000000))
+print('WAN up bandwidth: {0}  Mb'.format(fbx_connection_status_details['bandwidth_up']/1000000))
+print('WAN type: {0}'.format(fbx_connection_status_details['type']))
+print('WAN media: {0}'.format(fbx_connection_status_details['media']))
+
+# Extract xDSL interface stats  (GET /api/v6/connection/xdsl)
+fbx_connection_xdsl_details = fbx.connection.get_xdsl_stats()
+#print(fbx_connection_status_details)
+
+print('\n')
+print('### xDSL ###')
+#print('xDSL down : {0}'.format(fbx_connection_xdsl_details['down']))
+print('xDSL down maxrate: {0}'.format(fbx_connection_xdsl_details['down']['maxrate']))
+print('xDSL down attn: {0} dB'.format(fbx_connection_xdsl_details['down']['attn_10']/10))
+print('xDSL down snr: {0} dB'.format(fbx_connection_xdsl_details['down']['snr_10']/10))
+print('xDSL down crc: {0}'.format(fbx_connection_xdsl_details['down']['crc']))
+print('xDSL down fec: {0}'.format(fbx_connection_xdsl_details['down']['fec']))
+
+#print('xDSL up : {0}'.format(fbx_connection_xdsl_details['up']))
+print('xDSL up maxrate: {0}'.format(fbx_connection_xdsl_details['up']['maxrate']))
+print('xDSL up attn: {0} dB'.format(fbx_connection_xdsl_details['up']['attn_10']/10))
+print('xDSL up snr: {0} dB'.format(fbx_connection_xdsl_details['up']['snr_10']/10))
+print('xDSL up crc: {0}'.format(fbx_connection_xdsl_details['up']['crc']))
+print('xDSL up fec: {0}'.format(fbx_connection_xdsl_details['up']['fec']))
+
+#print('xDSL status : {0}'.format(fbx_connection_xdsl_details['status']))
+print('xDSL modulation : {0}'.format(fbx_connection_xdsl_details['status']['modulation']))
+print('xDSL protocol : {0}'.format(fbx_connection_xdsl_details['status']['protocol']))
+print('xDSL uptime : {0} h'.format(fbx_connection_xdsl_details['status']['uptime']/3600))
+
+# Close the freebox session
+fbx.close()
+

--- a/freepybox/api/connection.py
+++ b/freepybox/api/connection.py
@@ -1,0 +1,23 @@
+class Connection:
+
+    def __init__(self, access):
+        self._access = access
+
+
+    def get_status(self):
+        '''
+        Get Switch status
+        '''
+        return self._access.get('connection')
+
+    def get_status_details(self):
+        '''
+        Get Switch status
+        '''
+        return self._access.get('connection/full')
+
+    def get_logs(self):
+        '''
+        Get Switch status
+        '''
+        return self._access.get('connection/logs')

--- a/freepybox/api/connection.py
+++ b/freepybox/api/connection.py
@@ -6,18 +6,24 @@ class Connection:
 
     def get_status(self):
         '''
-        Get Switch status
+        Get Connection status
         '''
         return self._access.get('connection')
 
     def get_status_details(self):
         '''
-        Get Switch status
+        Get Connection detailed status
         '''
         return self._access.get('connection/full')
 
     def get_logs(self):
         '''
-        Get Switch status
+        Get Connection logs
         '''
         return self._access.get('connection/logs')
+
+    def get_xdsl_stats(self):
+        '''
+        Get port_id xDSL stats
+        '''
+        return self._access.get('connection/xdsl')

--- a/freepybox/freepybox.py
+++ b/freepybox/freepybox.py
@@ -11,6 +11,7 @@ import freepybox
 from freepybox.exceptions import *
 from freepybox.access import Access
 from freepybox.api.system import System
+from freepybox.api.connection import Connection
 from freepybox.api.dhcp import Dhcp
 from freepybox.api.switch import Switch
 from freepybox.api.lan import Lan
@@ -56,6 +57,7 @@ class Freepybox:
 
         # Instantiate freebox modules
         self.system = System(self._access)
+        self.connection = Connection(self._access)
         self.dhcp = Dhcp(self._access)
         self.switch = Switch(self._access)
         self.lan = Lan(self._access)


### PR DESCRIPTION
Hello,

I would push this pull request to add a connection module to get WAN and xDSL status.
It  works for me and my FreeboxV6 with V6 API.

```
from freepybox import Freepybox

# Instantiate Freepybox class using default application descriptor 
# and default token_file location
fbx = Freepybox()

# Connect to the freebox with default http protocol
# and default port 80
# Be ready to authorize the application on the Freebox if you use this
# example for the first time
fbx.open('mafreebox.freebox.fr', 80)

# Extract WAN interface status (GET /api/v6/connection/full) using connection API
fbx_connection_status_details = fbx.connection.get_status_details()
print(fbx_connection_status_details)

print('WAN ipv4 address: {0}'.format(fbx_connection_status_details['ipv4']))
print('WAN ipv6 address: {0}'.format(fbx_connection_status_details['ipv6']))
print('WAN status: {0}'.format(fbx_connection_status_details['state']))

print('WAN down bandwidth: {0}'.format(fbx_connection_status_details['bandwidth_down']))
print('WAN up bandwidth: {0}'.format(fbx_connection_status_details['bandwidth_up']))
print('WAN type: {0}'.format(fbx_connection_status_details['type']))
print('WAN media: {0}'.format(fbx_connection_status_details['media']))

print('xDSL down maxrate: {0}'.format(fbx_connection_xdsl_details['down']['maxrate']))
print('xDSL down attn: {0} dB'.format(fbx_connection_xdsl_details['down']['attn_10']/10))
print('xDSL down snr: {0} dB'.format(fbx_connection_xdsl_details['down']['snr_10']/10))
print('xDSL down crc: {0}'.format(fbx_connection_xdsl_details['down']['crc']))
print('xDSL down fec: {0}'.format(fbx_connection_xdsl_details['down']['fec']))

print('xDSL up maxrate: {0}'.format(fbx_connection_xdsl_details['up']['maxrate']))
print('xDSL up attn: {0} dB'.format(fbx_connection_xdsl_details['up']['attn_10']/10))
print('xDSL up snr: {0} dB'.format(fbx_connection_xdsl_details['up']['snr_10']/10))
print('xDSL up crc: {0}'.format(fbx_connection_xdsl_details['up']['crc']))
print('xDSL up fec: {0}'.format(fbx_connection_xdsl_details['up']['fec']))

print('xDSL modulation : {0}'.format(fbx_connection_xdsl_details['status']['modulation']))
print('xDSL protocol : {0}'.format(fbx_connection_xdsl_details['status']['protocol']))
print('xDSL uptime : {0} h'.format(fbx_connection_xdsl_details['status']['uptime']/3600))

# Close the freebox session
fbx.close()
```

```
$ python3 ./freepybox/freeboxV6-wan.py 
{   'bandwidth_down': 14820000,
    'bandwidth_up': 1020000,
    'bytes_down': 276225021,
    'bytes_up': 48628438,
    'ipv4': '78.197.C.D',
    'ipv4_port_range': [0, 65535],
    'ipv6': '2a01:e34:abcd:abcd::1',
    'media': 'xdsl',
    'rate_down': 4870,
    'rate_up': 2810,
    'state': 'up',
    'type': 'rfc2684'}
{   'bandwidth_down': 14820000,
    'bandwidth_up': 1020000,
    'bytes_down': 276225021,
    'bytes_up': 48628438,
    'ftth': {   'has_sfp': True,
                'link': False,
                'sfp_alim_ok': True,
                'sfp_has_power_report': False,
                'sfp_has_signal': False,
                'sfp_present': False},
    'ipv4': '78.197.C.D',
    'ipv4_port_range': [0, 65535],
    'ipv6': '2a01:e34:abcd:abcd::1',
    'media': 'xdsl',
    'rate_down': 4870,
    'rate_up': 2810,
    'state': 'up',
    'type': 'rfc2684',
    'xdsl': {   'modulation': 'adsl',
                'protocol': 'adsl2plus_a',
                'status': 'showtime',
                'uptime': 6602}}

WAN ipv4 address: 78.197.C.D
WAN ipv6 address: 2a01:e34:abcd:abcd::1
WAN status: up
WAN down bandwidth: 14820000
WAN up bandwidth: 1020000
WAN type: rfc2684
WAN media: xdsl

xDSL down maxrate: 17396
xDSL down attn: 29.5 dB
xDSL down snr: 5.1 dB
xDSL down crc: 0
xDSL down fec: 145
xDSL up maxrate: 1152
xDSL up attn: 15.0 dB
xDSL up snr: 7.5 dB
xDSL up crc: 0
xDSL up fec: 0
xDSL modulation : adsl
xDSL protocol : adsl2plus_a
xDSL uptime : 1.9908333333333332 h
```

Regards